### PR TITLE
Change DockerFile to ubuntu 20.04; correct OS check issue; run build automatically

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y git wget python3 python3-distutils sudo nano && sudo ln -s /usr/bin/python3 /usr/bin/python
 
@@ -6,6 +6,7 @@ WORKDIR /app
 
 RUN git clone https://github.com/aman-goel/avr.git
 WORKDIR /app/avr
+RUN sed -i 's/-n "$(uname -a | grep Ubuntu)"/1 -eq 1/g' build.sh ## to get rid of OS check
 RUN chmod +x build.sh && chmod +x deps/build_deps.sh ## run build.sh manually, as it requires some y-s
 
 CMD ["bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ENV TZ="America/Detroit"
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update && apt-get install -y git wget python3 python3-distutils sudo nano && sudo ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
@@ -7,7 +9,8 @@ WORKDIR /app
 RUN git clone https://github.com/aman-goel/avr.git
 WORKDIR /app/avr
 RUN sed -i 's/-n "$(uname -a | grep Ubuntu)"/1 -eq 1/g' build.sh ## to get rid of OS check
-RUN chmod +x build.sh && chmod +x deps/build_deps.sh ## run build.sh manually, as it requires some y-s
+RUN chmod +x build.sh && chmod +x deps/build_deps.sh
+RUN ./build.sh
 
 CMD ["bash"]
 


### PR DESCRIPTION
I fixed two issues I met when installing avr using docker: 
1. Changed environment to be ubuntu 20.04 (otherwise would have problem finding `distutils`, which is already deprecated in Python 3.12, the version Ubuntu 24.04 is using)
2. Added a line to modify the OS checking in Dockerfile before building build.sh (otherwise would recheck OS though it is already using ubuntu. And since docker shares the kernal with the host, there would be no 'ubuntu' when doing `uname -a`), leading to excuting  `yum` in original version)