### PR TITLE
std::random_shuffle was deprecated and is recommended to use std::shuffle instead

### DIFF
--- a/src/reach/reach_bt.cpp
+++ b/src/reach/reach_bt.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "reach_bt.h"
-
+#include "reach_random.h"
 #ifdef _BT
 
 #include <cstdlib>
@@ -749,7 +749,7 @@ int bt_API::s_check(long timeout_value, bool getModel) {
 	BT_SET_TIMEOUT(g_ctx);
 	TIME_S(start_time);
   boolector_reset_assumptions(g_ctx);
-  random_shuffle(m_assertions.begin(), m_assertions.end());
+  avr_rand::shuffle(m_assertions.begin(), m_assertions.end());
   for (auto& v: m_assertions)
 		boolector_assume(g_ctx, v);
 	for (auto& v: m_assertions_retract)
@@ -796,8 +796,8 @@ bt_result bt_API::s_check_mus(long timeout_value, bt_expr_vec& assumptions, bt_e
   BT_SET_TIMEOUT(g_ctx);
   TIME_S(start_time);
   boolector_reset_assumptions(g_ctx);
-  random_shuffle(m_assertions.begin(), m_assertions.end());
-  random_shuffle(assumptions.begin(), assumptions.end());
+  avr_rand::shuffle(m_assertions.begin(), m_assertions.end());
+  avr_rand::shuffle(assumptions.begin(), assumptions.end());
 	for (auto& v: m_assertions)
 		boolector_assume(g_ctx, v);
 	for (auto& v: m_assertions_retract)

--- a/src/reach/reach_cegar.cpp
+++ b/src/reach/reach_cegar.cpp
@@ -9,6 +9,7 @@
 
 
 #include "reach_core.h"
+#include "reach_random.h"
 #include <execinfo.h>	// to dump call stacks (backtrace, backtrace_symbols)
 
 namespace reach
@@ -3692,7 +3693,7 @@ void Reach::generalize_unsat_query(BR_QUERY& q, InstLL& muses, Solver* coreSolve
 
   if ((_numFrameRes % 50) == 0) {
   	InstV temp(softAnd.begin(), softAnd.end());
-  	random_shuffle(temp.begin(), temp.end());
+	avr_rand::shuffle(temp.begin(), temp.end());
   	copy(temp.begin(), temp.end(), softAnd.begin());
   }
   else

--- a/src/reach/reach_random.h
+++ b/src/reach/reach_random.h
@@ -1,0 +1,31 @@
+/************************************************************************************
+* AVR: Abstractly Verifying Reachability
+*
+* Copyright (c) 2016 - Present  Aman Goel and Karem Sakallah, University of Michigan.
+* All rights reserved.
+*
+*
+************************************************************************************/
+
+#pragma once
+
+#include <random>
+#include <algorithm>
+
+namespace avr_rand {
+    inline std::mt19937& get_random_engine() {
+        thread_local static std::random_device rd;
+        thread_local static std::mt19937 gen(rd());
+        return gen;
+    }
+
+    template<typename Container>
+    void shuffle(Container& container) {
+        std::shuffle(container.begin(), container.end(), get_random_engine());
+    }
+
+    template<typename Iterator>
+    void shuffle(Iterator begin, Iterator end) {
+        std::shuffle(begin, end, get_random_engine());
+    }
+}


### PR DESCRIPTION
The original `reach` code is throwing errors in latest Fedora/Ubuntu c++ compilers (gcc):
```
reach_bt.cpp: In member function ‘bt_result _bt::bt_API::s_check_mus(long int, bt_expr_vec&, bt_expr_vec&, bool)’:
reach_bt.cpp:799:17: error: ‘void std::random_shuffle(_RAIter, _RAIter) [with _RAIter = __gnu_cxx::__normal_iterator<BoolectorNode**, vector<BoolectorNode*> >]’ is deprecated: use 'std::shuffle' instead [-Werror=deprecated-declarations]
  799 |   random_shuffle(m_assertions.begin(), m_assertions.end());
      |   ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/14/algorithm:61,
                 from /usr/include/gmpxx.h:40,
                 from avr_word_netlist.h:26,
                 from reach_backend.h:24,
                 from reach_bt.h:23,
                 from reach_bt.cpp:18:
```

I tried to keep consistency encapsulating the random generator across the required functions, is also easy to update.